### PR TITLE
Make Quark dropoff work for storage devices.

### DIFF
--- a/src/main/java/rustic/common/tileentity/TileEntityBarrel.java
+++ b/src/main/java/rustic/common/tileentity/TileEntityBarrel.java
@@ -20,12 +20,19 @@ import net.minecraft.world.World;
 import net.minecraftforge.common.capabilities.Capability;
 import net.minecraftforge.items.CapabilityItemHandler;
 import net.minecraftforge.items.ItemStackHandler;
+import net.minecraftforge.fml.common.Optional;
 import rustic.common.util.ItemStackHandlerRustic;
 import rustic.core.Rustic;
+import vazkii.quark.base.handler.IDropoffManager;
 
-public class TileEntityBarrel extends TileEntityLockableLoot {
-	
-	private ItemStackHandlerRustic itemStackHandler = new ItemStackHandlerRustic(27) {
+@Optional.Interface(modid="quark", iface="vazkii.quark.base.handler.IDropoffManager")
+public class TileEntityBarrel extends TileEntityLockableLoot implements IDropoffManager {
+    @Optional.Method(modid="quark")
+    public boolean acceptsDropoff() {
+        return true;
+    }
+
+    private ItemStackHandlerRustic itemStackHandler = new ItemStackHandlerRustic(27) {
         @Override
         protected void onContentsChanged(int slot) {
             TileEntityBarrel.this.markDirty();

--- a/src/main/java/rustic/common/tileentity/TileEntityCabinet.java
+++ b/src/main/java/rustic/common/tileentity/TileEntityCabinet.java
@@ -42,17 +42,25 @@ import net.minecraftforge.fml.relauncher.SideOnly;
 import net.minecraftforge.items.CapabilityItemHandler;
 import net.minecraftforge.items.IItemHandler;
 import net.minecraftforge.items.ItemStackHandler;
+import net.minecraftforge.fml.common.Optional;
 import rustic.common.blocks.BlockCabinet;
 import rustic.common.blocks.ModBlocks;
 import rustic.common.inventory.DoubleCabinetItemHandler;
 import rustic.common.util.ItemStackHandlerRustic;
+import vazkii.quark.base.handler.IDropoffManager;
 
-public class TileEntityCabinet extends TileEntityLockableLoot implements ITickable {
+@Optional.Interface(modid="quark", iface="vazkii.quark.base.handler.IDropoffManager")
+public class TileEntityCabinet extends TileEntityLockableLoot implements ITickable, IDropoffManager {
 
 	public float lidAngle = 0;
 	public float prevLidAngle = 0;
 	public int numPlayersUsing = 0;
 	private int ticksSinceSync = 0;
+
+    @Optional.Method(modid="quark")
+    public boolean acceptsDropoff() {
+        return true;
+    }
 
 	private ItemStackHandlerRustic itemStackHandler = new ItemStackHandlerRustic (27) {
 		@Override

--- a/src/main/java/rustic/common/tileentity/TileEntityVase.java
+++ b/src/main/java/rustic/common/tileentity/TileEntityVase.java
@@ -21,11 +21,18 @@ import net.minecraft.world.World;
 import net.minecraftforge.common.capabilities.Capability;
 import net.minecraftforge.items.CapabilityItemHandler;
 import net.minecraftforge.items.ItemStackHandler;
+import net.minecraftforge.fml.common.Optional;
 import rustic.common.util.ItemStackHandlerRustic;
+import vazkii.quark.base.handler.IDropoffManager;
 
-public class TileEntityVase extends TileEntityLockableLoot {
-	
-	private ItemStackHandlerRustic itemStackHandler = new ItemStackHandlerRustic(27) {
+@Optional.Interface(modid="quark", iface="vazkii.quark.base.handler.IDropoffManager")
+public class TileEntityVase extends TileEntityLockableLoot implements IDropoffManager {
+    @Optional.Method(modid="quark")
+    public boolean acceptsDropoff() {
+        return true;
+    }
+
+    private ItemStackHandlerRustic itemStackHandler = new ItemStackHandlerRustic(27) {
         @Override
         protected void onContentsChanged(int slot) {
             TileEntityVase.this.markDirty();

--- a/src/main/java/vazkii/quark/base/handler/IDropoffManager.java
+++ b/src/main/java/vazkii/quark/base/handler/IDropoffManager.java
@@ -1,0 +1,18 @@
+/**
+ * This class was created by <Vazkii>. It's distributed as
+ * part of the Quark Mod. Get the Source Code in github:
+ * https://github.com/Vazkii/Quark
+ *
+ * Quark is Open Source and distributed under the
+ * [ADD-LICENSE-HERE]
+ *
+ * File Created @ [28/03/2016, 17:05:38 (GMT)]
+ */
+package vazkii.quark.base.handler;
+
+// API class, for modders
+public interface IDropoffManager {
+
+	public boolean acceptsDropoff();
+
+}


### PR DESCRIPTION
This should implement the suggestion in #42.

Specifically, it targets dry barrels, cabinets, and vases.