### PR TITLE
Add call to ForgeHooks#getTotalArmorValue for EntityPlayer

### DIFF
--- a/src/main/java/rustic/client/EventHandlerClient.java
+++ b/src/main/java/rustic/client/EventHandlerClient.java
@@ -46,6 +46,7 @@ import net.minecraftforge.client.event.RenderBlockOverlayEvent;
 import net.minecraftforge.client.event.RenderBlockOverlayEvent.OverlayType;
 import net.minecraftforge.client.event.RenderGameOverlayEvent;
 import net.minecraftforge.client.event.TextureStitchEvent;
+import net.minecraftforge.common.ForgeHooks;
 import net.minecraftforge.fluids.BlockFluidBase;
 import net.minecraftforge.fluids.FluidStack;
 import net.minecraftforge.fluids.FluidUtil;
@@ -284,6 +285,10 @@ public class EventHandlerClient {
 				GlStateManager.enableBlend();
 
 				int armorLevel = viewEntity.getTotalArmorValue();
+
+				if (viewEntity instanceof EntityPlayer) {
+					armorLevel = ForgeHooks.getTotalArmorValue((EntityPlayer) viewEntity);
+				}
 
 				int armorRows = MathHelper.ceil(armorLevel / 20.0F);
 				int rowHeight = Math.min(Math.max(10 - (armorRows - 2), 3), 10);


### PR DESCRIPTION
This fixes instances of ISpecialArmor not displaying their armor values on your custom HUD.
See Botania as an example of this bug, where the armor is using ISpecialArmor for it's armor values, of which are only accessible through the player sensitive `ForgeHooks#getTotalArmorValue`