### PR TITLE
condenser CrT integration: bottles can be null

### DIFF
--- a/src/main/java/rustic/common/tileentity/TileEntityCondenser.java
+++ b/src/main/java/rustic/common/tileentity/TileEntityCondenser.java
@@ -90,10 +90,10 @@ public class TileEntityCondenser extends TileEntityCondenserBase {
 			return false;
 		}
 
-		if (internalStackHandler.getStackInSlot(SLOT_BOTTLE).isEmpty()
-				|| internalStackHandler.getStackInSlot(SLOT_BOTTLE).getCount() < 1) {
-			return false;
-		}
+//		if (internalStackHandler.getStackInSlot(SLOT_BOTTLE).isEmpty()
+//				|| internalStackHandler.getStackInSlot(SLOT_BOTTLE).getCount() < 1) {
+//			return false;
+//		}
 
 			
 		if (!((BlockCondenser) state.getBlock()).hasRetorts(world, pos, state)) {

--- a/src/main/java/rustic/common/tileentity/TileEntityCondenserAdvancedBottom.java
+++ b/src/main/java/rustic/common/tileentity/TileEntityCondenserAdvancedBottom.java
@@ -97,10 +97,10 @@ public class TileEntityCondenserAdvancedBottom extends TileEntityCondenserBase {
 			return false;
 		}
 		
-		if (internalStackHandler.getStackInSlot(SLOT_BOTTLE).isEmpty()
-				|| internalStackHandler.getStackInSlot(SLOT_BOTTLE).getCount() < 1) {
-			return false;
-		}
+//		if (internalStackHandler.getStackInSlot(SLOT_BOTTLE).isEmpty()
+//				|| internalStackHandler.getStackInSlot(SLOT_BOTTLE).getCount() < 1) {
+//			return false;
+//		}
 
 		if (!((BlockCondenserAdvanced) state.getBlock()).hasRetorts(world, pos, state)) {
 			return false;

--- a/src/main/java/rustic/compat/crafttweaker/Condenser.java
+++ b/src/main/java/rustic/compat/crafttweaker/Condenser.java
@@ -7,7 +7,6 @@ import crafttweaker.api.item.IIngredient;
 import crafttweaker.api.item.IItemStack;
 import crafttweaker.api.liquid.ILiquidStack;
 import crafttweaker.api.minecraft.CraftTweakerMC;
-import net.minecraft.init.Items;
 import net.minecraft.item.ItemStack;
 import net.minecraftforge.fluids.FluidRegistry;
 import net.minecraftforge.fluids.FluidStack;
@@ -49,9 +48,6 @@ public class Condenser {
 		if (inputs.length > 3) {
 			throw new IllegalArgumentException("Condenser recipe has at most 3 inputs");
 		}
-		if (bottle == null) {
-			bottle = CraftTweakerMC.getIItemStack(new ItemStack(Items.GLASS_BOTTLE));
-		}
 		ICondenserRecipe r = new CrTCondenserRecipe(CraftTweakerMC.getItemStack(output), inputs, modifier, bottle);
 		CraftTweakerAPI.apply(new Add(r));
 	}
@@ -60,9 +56,6 @@ public class Condenser {
 	public static void addRecipe(@NotNull IItemStack output, @NotNull IIngredient[] inputs, IIngredient modifier, IIngredient bottle, ILiquidStack fluid) {
 		if (inputs.length > 3) {
 			throw new IllegalArgumentException("Condenser recipe has at most 3 inputs");
-		}
-		if (bottle == null) {
-			bottle = CraftTweakerMC.getIItemStack(new ItemStack(Items.GLASS_BOTTLE));
 		}
 		if (fluid == null) {
 			fluid = CraftTweakerMC.getILiquidStack(new FluidStack(FluidRegistry.WATER, 125));
@@ -75,9 +68,6 @@ public class Condenser {
 	public static void addRecipe(@NotNull IItemStack output, @NotNull IIngredient[] inputs, IIngredient modifier, IIngredient bottle, ILiquidStack fluid, int time) {
 		if (inputs.length > 3) {
 			throw new IllegalArgumentException("Condenser recipe has at most 3 inputs");
-		}
-		if (bottle == null) {
-			bottle = CraftTweakerMC.getIItemStack(new ItemStack(Items.GLASS_BOTTLE));
 		}
 		if (fluid == null) {
 			fluid = CraftTweakerMC.getILiquidStack(new FluidStack(FluidRegistry.WATER, 125));

--- a/src/main/java/rustic/compat/crafttweaker/CrTCondenserRecipe.java
+++ b/src/main/java/rustic/compat/crafttweaker/CrTCondenserRecipe.java
@@ -1,5 +1,6 @@
 package rustic.compat.crafttweaker;
 
+import java.util.Collections;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -32,15 +33,15 @@ public class CrTCondenserRecipe implements ICondenserRecipe {
 		this(output, inputs, modifier, CraftTweakerMC.getIItemStack(new ItemStack(Items.GLASS_BOTTLE)));
 	}
 	
-	public CrTCondenserRecipe(@Nonnull ItemStack output, IIngredient[] inputs, IIngredient modifier, @Nonnull IIngredient bottle) {
+	public CrTCondenserRecipe(@Nonnull ItemStack output, IIngredient[] inputs, IIngredient modifier, IIngredient bottle) {
 		this(output, inputs, modifier, bottle, new FluidStack(FluidRegistry.WATER, 125));
 	}
 	
-	public CrTCondenserRecipe(@Nonnull ItemStack output, IIngredient[] inputs, IIngredient modifier, @Nonnull IIngredient bottle, @Nonnull FluidStack fluid) {
+	public CrTCondenserRecipe(@Nonnull ItemStack output, IIngredient[] inputs, IIngredient modifier, IIngredient bottle, @Nonnull FluidStack fluid) {
 		this(output, inputs, modifier, bottle, fluid, 400);
 	}
 	
-	public CrTCondenserRecipe(@Nonnull ItemStack output, IIngredient[] inputs, IIngredient modifier, @Nonnull IIngredient bottle, @Nonnull FluidStack fluid, int time) {
+	public CrTCondenserRecipe(@Nonnull ItemStack output, IIngredient[] inputs, IIngredient modifier, IIngredient bottle, @Nonnull FluidStack fluid, int time) {
 		this.output = output;
 		this.fluid = fluid;
 		this.bottle = bottle;
@@ -59,12 +60,12 @@ public class CrTCondenserRecipe implements ICondenserRecipe {
 			return false;
 		}
 		if (
-				(this.modifier != null && !this.modifier.matchesExact(CraftTweakerMC.getIItemStack((modifier))))
+				(this.modifier != null && !this.modifier.matchesExact(CraftTweakerMC.getIItemStack(modifier)))
 				|| (this.modifier == null && !modifier.isEmpty())
 		) {
 			return false;
 		}
-		if (!this.bottle.matchesExact(CraftTweakerMC.getIItemStack(bottle))) {
+		if (this.bottle != null && !this.bottle.matchesExact(CraftTweakerMC.getIItemStack(bottle))) {
 			return false;
 		}
 		
@@ -120,6 +121,9 @@ public class CrTCondenserRecipe implements ICondenserRecipe {
 
 	@Override
 	public List<ItemStack> getBottles() {
+		if (this.bottle == null) {
+			return Collections.singletonList(ItemStack.EMPTY);
+		}
 		return this.bottle.getItems().stream().map(CraftTweakerMC::getItemStack).collect(Collectors.toList());
 	}
 
@@ -156,6 +160,9 @@ public class CrTCondenserRecipe implements ICondenserRecipe {
 
 	@Override
 	public int getBottleConsumption(ItemStack bottle) {
+		if (this.bottle == null) {
+			return 0;
+		}
 		IItemStack btl = CraftTweakerMC.getIItemStack(bottle);
 		for (IItemStack stack : this.bottle.getItems()) {
 			if (stack.matchesExact(btl)) {


### PR DESCRIPTION
I very slightly modified the code, so that supplying `null` in the condenser's crafttweaker integration does not default to a glass bottle (allowing recipes with no bottle, e.g. for solid recipes).
If not supplied in the script, the bottle still defaults to a glass bottle

*caveat*: I did not test this in multiplayer. But the changes are so small that it should not be a problem