### PR TITLE
Update TileEntityApiary.java

### DIFF
--- a/src/main/java/rustic/common/tileentity/TileEntityApiary.java
+++ b/src/main/java/rustic/common/tileentity/TileEntityApiary.java
@@ -1,6 +1,7 @@
 package rustic.common.tileentity;
 
 import java.util.Random;
+import java.lang.Math;
 
 import javax.annotation.Nonnull;
 
@@ -168,7 +169,7 @@ public class TileEntityApiary extends TileEntity implements ITickable {
 				}
 			}
 
-			if (Config.BEE_GROWTH_MULTIPLIER != 0 && random.nextInt((int) (2048F / (numBees * Config.BEE_GROWTH_MULTIPLIER))) == 0) {
+			if (Config.BEE_GROWTH_MULTIPLIER != 0 && random.nextInt(Math.ceil(2048F / (numBees * Config.BEE_GROWTH_MULTIPLIER))) == 0) {
 				int randX = random.nextInt(9) - 4;
 				int randZ = random.nextInt(9) - 4;
 				int x = this.getPos().getX();


### PR DESCRIPTION
Change from cast to Math.ceil in the nextInt so that with >= 2048 bees it doesn't end up with rand.nextInt(0) causing an exception about it needing to be positive.
This was found as an issue in Heavens of Sorcery where we are overriding maxium stack size (to 8192 in the case of the bees).