### PR TITLE
Evaporating basin CrT and interaction improvements

### DIFF
--- a/src/main/java/rustic/common/crafting/EvaporatingBasinRecipe.java
+++ b/src/main/java/rustic/common/crafting/EvaporatingBasinRecipe.java
@@ -1,9 +1,10 @@
 package rustic.common.crafting;
 
 import net.minecraft.item.ItemStack;
+import net.minecraftforge.fluids.Fluid;
 import net.minecraftforge.fluids.FluidStack;
 
-public class EvaporatingBasinRecipe {
+public class EvaporatingBasinRecipe implements IEvaporatingBasinRecipe {
 
 	protected FluidStack input;
 	protected ItemStack output;
@@ -13,19 +14,31 @@ public class EvaporatingBasinRecipe {
 		this.output = out;
 	}
 	
-	public boolean matches(FluidStack in) {
-		if (in.containsFluid(this.input)) {
-			return true;
-		}
-		return false;
-	}
-	
-	public ItemStack getResult() {
-		return this.output.copy();
-	}
+//	public boolean matches(FluidStack in) {
+//		if (in.containsFluid(this.input)) {
+//			return true;
+//		}
+//		return false;
+//	}
 	
 	public FluidStack getInput() {
 		return this.input.copy();
+	}
+	
+	public Fluid getFluid() {
+		return this.input.getFluid();
+	}
+	
+	public int getAmount() {
+		return this.input.amount;
+	}
+	
+	public ItemStack getOutput() {
+		return this.output.copy();
+	}
+
+	public int getTime() {
+		return this.input.amount;
 	}
 	
 }

--- a/src/main/java/rustic/common/crafting/IEvaporatingBasinRecipe.java
+++ b/src/main/java/rustic/common/crafting/IEvaporatingBasinRecipe.java
@@ -1,0 +1,13 @@
+package rustic.common.crafting;
+
+import net.minecraft.item.ItemStack;
+import net.minecraftforge.fluids.Fluid;
+import net.minecraftforge.fluids.FluidStack;
+
+public interface IEvaporatingBasinRecipe {
+	Fluid getFluid();
+	int getAmount();
+	FluidStack getInput();
+	ItemStack getOutput();
+	int getTime();
+}

--- a/src/main/java/rustic/common/crafting/Recipes.java
+++ b/src/main/java/rustic/common/crafting/Recipes.java
@@ -1,6 +1,7 @@
 package rustic.common.crafting;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 
 import net.minecraft.block.state.IBlockState;
@@ -13,6 +14,7 @@ import net.minecraft.item.crafting.IRecipe;
 import net.minecraft.item.crafting.Ingredient;
 import net.minecraft.potion.PotionEffect;
 import net.minecraft.util.ResourceLocation;
+import net.minecraftforge.fluids.Fluid;
 import net.minecraftforge.fluids.FluidRegistry;
 import net.minecraftforge.fluids.FluidStack;
 import net.minecraftforge.fluids.FluidUtil;
@@ -37,7 +39,8 @@ import rustic.core.Rustic;
 public class Recipes {
 
 	public static List<CrushingTubRecipe> crushingTubRecipes = new ArrayList<CrushingTubRecipe>();
-	public static List<EvaporatingBasinRecipe> evaporatingRecipes = new ArrayList<EvaporatingBasinRecipe>();
+	//public static List<EvaporatingBasinRecipe> evaporatingRecipes = new ArrayList<EvaporatingBasinRecipe>();
+	public static HashMap<Fluid, IEvaporatingBasinRecipe> evaporatingRecipes = new HashMap<Fluid, IEvaporatingBasinRecipe>();
 	public static List<ICondenserRecipe> condenserRecipes = new ArrayList<ICondenserRecipe>();
 	public static List<BrewingBarrelRecipe> brewingRecipes = new ArrayList<BrewingBarrelRecipe>();
 
@@ -349,8 +352,13 @@ public class Recipes {
 	}
 
 	private static void addEvaporatingRecipes() {
-		evaporatingRecipes.add(new EvaporatingBasinRecipe(new ItemStack(ModItems.IRON_DUST_TINY, 1),
-				new FluidStack(ModFluids.IRONBERRY_JUICE, 500)));
+		evaporatingRecipes.put(
+				ModFluids.IRONBERRY_JUICE,
+				new EvaporatingBasinRecipe(
+						new ItemStack(ModItems.IRON_DUST_TINY, 1),
+						new FluidStack(ModFluids.IRONBERRY_JUICE, 500)
+				)
+		);
 	}
 
 	private static void addCondenserRecipes() {

--- a/src/main/java/rustic/compat/crafttweaker/CrTEvaporatingBasinRecipe.java
+++ b/src/main/java/rustic/compat/crafttweaker/CrTEvaporatingBasinRecipe.java
@@ -1,0 +1,48 @@
+package rustic.compat.crafttweaker;
+
+import java.util.List;
+
+import net.minecraft.item.ItemStack;
+import net.minecraftforge.fluids.Fluid;
+import net.minecraftforge.fluids.FluidStack;
+import rustic.common.crafting.ICondenserRecipe;
+import rustic.common.crafting.IEvaporatingBasinRecipe;
+
+public class CrTEvaporatingBasinRecipe implements IEvaporatingBasinRecipe {
+	
+	protected FluidStack input;
+	protected ItemStack output;
+	protected int time;
+	
+	public CrTEvaporatingBasinRecipe(ItemStack out, FluidStack in, int time) {
+		this.output = out;
+		this.input = in;
+		this.time = time;
+	}
+
+	@Override
+	public Fluid getFluid() {
+		return this.input.getFluid();
+	}
+
+	@Override
+	public int getAmount() {
+		return this.input.amount;
+	}
+	
+	@Override
+	public FluidStack getInput() {
+		return this.input.copy();
+	}
+	
+	@Override
+	public ItemStack getOutput() {
+		return this.output.copy();
+	}
+
+	@Override
+	public int getTime() {
+		return this.time;
+	}
+
+}

--- a/src/main/java/rustic/compat/jei/EvaporatingRecipeWrapper.java
+++ b/src/main/java/rustic/compat/jei/EvaporatingRecipeWrapper.java
@@ -5,19 +5,20 @@ import mezz.jei.api.recipe.BlankRecipeWrapper;
 import net.minecraft.item.ItemStack;
 import net.minecraftforge.fluids.FluidStack;
 import rustic.common.crafting.EvaporatingBasinRecipe;
+import rustic.common.crafting.IEvaporatingBasinRecipe;
 
 public class EvaporatingRecipeWrapper extends BlankRecipeWrapper {
 
-	public EvaporatingBasinRecipe recipe = null;
+	public IEvaporatingBasinRecipe recipe = null;
 	
-	public EvaporatingRecipeWrapper(EvaporatingBasinRecipe recipe) {
+	public EvaporatingRecipeWrapper(IEvaporatingBasinRecipe recipe) {
 		this.recipe = recipe;
 	}
 	
 	@Override
 	public void getIngredients(IIngredients ingredients) {
 		ingredients.setInput(FluidStack.class, recipe.getInput());
-		ingredients.setOutput(ItemStack.class, recipe.getResult());
+		ingredients.setOutput(ItemStack.class, recipe.getOutput());
 	}
 
 }

--- a/src/main/java/rustic/compat/jei/EvaporatingRecipeWrapperFactory.java
+++ b/src/main/java/rustic/compat/jei/EvaporatingRecipeWrapperFactory.java
@@ -3,11 +3,12 @@ package rustic.compat.jei;
 import mezz.jei.api.recipe.IRecipeWrapper;
 import mezz.jei.api.recipe.IRecipeWrapperFactory;
 import rustic.common.crafting.EvaporatingBasinRecipe;
+import rustic.common.crafting.IEvaporatingBasinRecipe;
 
-public class EvaporatingRecipeWrapperFactory implements IRecipeWrapperFactory<EvaporatingBasinRecipe> {
+public class EvaporatingRecipeWrapperFactory implements IRecipeWrapperFactory<IEvaporatingBasinRecipe> {
 
 	@Override
-	public IRecipeWrapper getRecipeWrapper(EvaporatingBasinRecipe recipe) {
+	public IRecipeWrapper getRecipeWrapper(IEvaporatingBasinRecipe recipe) {
 		return new EvaporatingRecipeWrapper(recipe);
 	}
 

--- a/src/main/java/rustic/compat/jei/RusticJEIPlugin.java
+++ b/src/main/java/rustic/compat/jei/RusticJEIPlugin.java
@@ -24,6 +24,7 @@ import rustic.common.crafting.BrewingBarrelRecipe;
 import rustic.common.crafting.CrushingTubRecipe;
 import rustic.common.crafting.EvaporatingBasinRecipe;
 import rustic.common.crafting.ICondenserRecipe;
+import rustic.common.crafting.IEvaporatingBasinRecipe;
 import rustic.common.crafting.Recipes;
 import rustic.common.items.ModItems;
 
@@ -58,12 +59,12 @@ public class RusticJEIPlugin implements IModPlugin {
 		reg.handleRecipes(CrushingTubRecipe.class, new CrushingTubRecipeWrapperFactory(), "rustic.crushing_tub");
 
 		reg.addRecipeCategories(new EvaporatingRecipeCategory(guiHelper));
-		ArrayList<EvaporatingBasinRecipe> evaporatingRecipes = new ArrayList<EvaporatingBasinRecipe>();
-		for (int i = 0; i < Recipes.evaporatingRecipes.size(); i++) {
-			evaporatingRecipes.add(Recipes.evaporatingRecipes.get(i));
+		ArrayList<IEvaporatingBasinRecipe> evaporatingRecipes = new ArrayList<IEvaporatingBasinRecipe>();
+		for (IEvaporatingBasinRecipe recipe : Recipes.evaporatingRecipes.values()) {
+			evaporatingRecipes.add(recipe);
 		}
 		reg.addRecipes(evaporatingRecipes, "rustic.evaporating");
-		reg.handleRecipes(EvaporatingBasinRecipe.class, new EvaporatingRecipeWrapperFactory(), "rustic.evaporating");
+		reg.handleRecipes(IEvaporatingBasinRecipe.class, new EvaporatingRecipeWrapperFactory(), "rustic.evaporating");
 
 		reg.addRecipeCategories(new AdvancedAlchemyRecipeCategory(guiHelper));
 		reg.addRecipes(AdvancedAlchemyRecipeMaker.getAlchemyRecipes(helper), "rustic.alchemy_advanced");


### PR DESCRIPTION
This PR features the following changes:
- Added a new method to the CraftTweaker integration, `EvaporatingBasin.addRecipe(IItemStack output, ILiquidStack input, int time)` that allows pack maker to specify the time it takes to evaporate the whol quantity
    - Internal changes required to make that work. Most notably, `Recipes.evaporatingRecipe` is now a HashMap from fluid to recipe
    - Updated the JEI integration accordingly
- Made the Evaporating basin only accept fluids it has a recipe for
- Prevented accidental placement of fluids when clicking an evaporating basin with a fluid container, while:
    - the evaporating basin doesn't have enough space; OR
    - the fluid is not accepted by the evaporating basin
The evaporating basin now tells the game it handled the right click, even if filling was unsuccessful.

I tested with quick scripts in both single-player and multiplayer
